### PR TITLE
add submodules for ecs and lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 
-# terraform-aws-iam-ecs
+# terraform-aws-iam
 
 terraform module for installing ecs integrations
 
 # Usage
 
 ```hcl
-module "effx_ecs" {
-  source  = "git::github.com/effxhq/terraform-aws-iam-ecs.git?ref=main"
+module "effx_aws_integration" {
+  source  = "git::github.com/effxhq/terraform-aws-iam.git?ref=main"
+  enable_ecs = true // defaults to true
+  enable_lambda = true
   resource_tags = []
 }
 ```

--- a/ecs/main.tf
+++ b/ecs/main.tf
@@ -1,0 +1,38 @@
+resource "aws_iam_policy" "effx_aws_ecs_integration" {
+  count = var.enable_ecs ? 1 : 0
+  name  = "effx-AWS-ECS-Integration-Policy"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : [
+          "cloudformation:Describe*",
+          "cloudformation:Get*",
+          "cloudformation:List*",
+          "cloudtrail:DescribeTrails",
+          "cloudtrail:GetTrailStatus",
+          "cloudwatch:Describe*",
+          "cloudwatch:Get*",
+          "cloudwatch:List*",
+          "ecs:Describe*",
+          "ecs:List*",
+          "health:DescribeEvents",
+          "health:DescribeEventDetails",
+          "health:DescribeAffectedEntities",
+          "logs:List*",
+          "logs:Describe*",
+          "states:ListStateMachines",
+          "states:DescribeStateMachine",
+          "tag:GetResources",
+          "tag:GetTagKeys",
+          "tag:GetTagValues",
+          "xray:BatchGetTraces",
+          "xray:GetTraceSummaries"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*"
+      }
+    ]
+  })
+}

--- a/ecs/outputs.tf
+++ b/ecs/outputs.tf
@@ -1,0 +1,4 @@
+output "iam_policy_arn" {
+  value = aws_iam_policy.effx_aws_ecs_integration.arn
+}
+

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -1,0 +1,4 @@
+variable "enable_ecs" {
+  default     = true
+  description = "enable or disable the ecs integration"
+}

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -1,0 +1,38 @@
+resource "aws_iam_policy" "effx_aws_lambda_integration_policy" {
+  count = var.enable_lambda ? 1 : 0
+  name = "effx-AWS-Lambda-Integration-Policy"
+
+  policy = jsonencode({{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "cloudformation:Describe*",
+                "cloudformation:Get*",
+                "cloudformation:List*",
+                "cloudtrail:DescribeTrails",
+                "cloudtrail:GetTrailStatus",
+                "cloudwatch:Describe*",
+                "cloudwatch:Get*",
+                "cloudwatch:List*",
+                "health:DescribeEvents",
+                "health:DescribeEventDetails",
+                "health:DescribeAffectedEntities",
+                "lambda:List*",
+                "lambda:Get*",
+                "logs:List*",
+                "logs:Describe*",
+                "states:ListStateMachines",
+                "states:DescribeStateMachine",
+                "tag:GetResources",
+                "tag:GetTagKeys",
+                "tag:GetTagValues",
+                "xray:BatchGetTraces",
+                "xray:GetTraceSummaries"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ]
+})
+}

--- a/lambda/outputs.tf
+++ b/lambda/outputs.tf
@@ -1,0 +1,4 @@
+output "iam_policy_arn" {
+  value = aws_iam_policy.effx_aws_lambda_integration_policy.arn
+}
+

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -1,0 +1,4 @@
+variable "enable_lambda" {
+  default     = true
+  description = "enable or disable the lambda integration"
+}

--- a/main.tf
+++ b/main.tf
@@ -18,11 +18,13 @@ resource "random_string" "external_id" {
 }
 
 module "effx_aws_ecs" {
-  source = "./ecs"
+  source     = "./ecs"
+  enable_ecs = var.enable_ecs
 }
 
 module "effx_aws_lambda" {
-  source = "./lambda"
+  source        = "./lambda"
+  enable_lambda = var.enable_lambda
 }
 
 resource "aws_iam_role" "effx_aws_ecs_integration_role" {

--- a/main.tf
+++ b/main.tf
@@ -17,48 +17,18 @@ resource "random_string" "external_id" {
   length = 32
 }
 
+module "effx_aws_ecs" {
+  source = "./ecs"
+}
+
+module "effx_aws_lambda" {
+  source = "./lambda"
+}
+
 resource "aws_iam_role" "effx_aws_ecs_integration_role" {
   name                = "effx-AWS-ECS-Integration-Role"
   assume_role_policy  = data.aws_iam_policy_document.instance_assume_role_policy.json
-  managed_policy_arns = [aws_iam_policy.effx_aws_ecs_integration.arn]
+  managed_policy_arns = [effx_aws_ecs.iam_policy_arn, effx_aws_lambda.iam_policy_arn]
 
   tags = var.resource_tags
-}
-
-resource "aws_iam_policy" "effx_aws_ecs_integration" {
-  name = "effx-AWS-ECS-Integration"
-
-  policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Action" : [
-          "cloudformation:Describe*",
-          "cloudformation:Get*",
-          "cloudformation:List*",
-          "cloudtrail:DescribeTrails",
-          "cloudtrail:GetTrailStatus",
-          "cloudwatch:Describe*",
-          "cloudwatch:Get*",
-          "cloudwatch:List*",
-          "ecs:Describe*",
-          "ecs:List*",
-          "health:DescribeEvents",
-          "health:DescribeEventDetails",
-          "health:DescribeAffectedEntities",
-          "logs:List*",
-          "logs:Describe*",
-          "states:ListStateMachines",
-          "states:DescribeStateMachine",
-          "tag:GetResources",
-          "tag:GetTagKeys",
-          "tag:GetTagValues",
-          "xray:BatchGetTraces",
-          "xray:GetTraceSummaries"
-        ],
-        "Effect" : "Allow",
-        "Resource" : "*"
-      }
-    ]
-  })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,3 +4,13 @@ variable "resource_tags" {
   default     = {}
   description = "tags to add to the aws effx integration role"
 }
+
+variable "enable_ecs" {
+  default     = true
+  description = "enable or disable the ecs integration"
+}
+
+variable "enable_lambda" {
+  default     = true
+  description = "enable or disable the lambda integration"
+}


### PR DESCRIPTION
[ch1614]
# Usage

```hcl
module "effx_aws_integration" {
  source  = "git::github.com/effxhq/terraform-aws-iam.git?ref=main"
  enable_ecs = true // defaults to true
  enable_lambda = true
  resource_tags = []
}
```

- added submodules for ecs and lambda